### PR TITLE
Fix: Signed-unsigned conversion warning

### DIFF
--- a/src/cd.c
+++ b/src/cd.c
@@ -75,7 +75,7 @@ void track_delete(Track *track)
 
 void cd_delete (Cd *cd)
 {
-	size_t i;
+	int i;
 	if (cd->cdtext)
 		cdtext_delete(cd->cdtext);
 	if (cd->catalog)


### PR DESCRIPTION
This PR fixes a stray signed/unsigned conversion warning in cd.c's `cd_delete()`.

This was caught in the [CI testing cycle for libAudio macOS builds](https://github.com/dragonCodecs/libAudio/actions/runs/6029542457/job/16359327417#step:11:28)